### PR TITLE
Use $$restProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Use [`$$restProps`](https://svelte.dev/docs#template-syntax-attributes-and-props) instead of manual deleting of specified props ([#6](https://github.com/SeanMcP/svelte-emoji/pull/6)) - [`@himynameisdave`](https://github.com/himynameisdave).
+
 ## [1.0.2] - 2020-01-06
 
 - First stable release of `svelte-emoji` 🎉

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -3,10 +3,6 @@
     export let label = null
 
     const hidden = !label ? true : null
-
-    const rest = {...$$props}
-    delete rest.symbol
-    delete rest.label
 </script>
 
-<span aria-hidden={hidden} aria-label={label} role="img" {...rest}>{symbol}</span>
+<span aria-hidden={hidden} aria-label={label} role="img" {...$$restProps}>{symbol}</span>


### PR DESCRIPTION
Instead of storing a new `rest` variable, and then `delete`ing the declared props, let's make use of Svelte's built-in `$$restProps` feature.

From [the docs](https://svelte.dev/docs#template-syntax-attributes-and-props):

> _`$$restProps` contains only the props which are not declared with export. It can be used to pass down other unknown attributes to an element in a component._

