### PR TITLE
📝 Install the package as a devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This component was ported to Svelte from [`a11y-react-emoji`](https://npm.im/a11
 Add `svelte-emoji` to your project:
 
 ```sh
-npm install svelte-emoji
+npm install -D svelte-emoji
 # or
-yarn add svelte-emoji
+yarn add -D svelte-emoji
 ```
 
 ## Use


### PR DESCRIPTION
From this Stackoverflow post https://stackoverflow.com/questions/68190803/should-a-svelte-package-be-a-dependency-or-a-devdependency :

> prefer to keep everything as a devDependency. I think it makes sense because Svelte is a compiler, and the packages are only needed at compile-time

So I would recommend in the documentation to install the package as a devDependencies.